### PR TITLE
Remove dependency on job that doesn't exist

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ jobs:
   release:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [ lint ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Trying to fix an error like seen in [a recent workflow run](https://github.com/coldspire/upcoming-music/actions/runs/8227082853):

> The workflow is not valid. .github/workflows/ci.yaml (Line: 12, Col: 3): The workflow must contain at least one job with no dependencies.