### PR TITLE
Fix bot failures

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -72,7 +72,7 @@ const server = {
 	verifyDiscordRequest,
 	fetch: async function (request, env) {
 		const releasesRaw = await getUpcomingMusicValues(env.SHEETS_API_KEY, env.SHEET_ID);
-		return router.handle(request, env, releasesRaw);
+		return router.fetch(request, env, releasesRaw);
 	},
 };
 

--- a/src/server.js
+++ b/src/server.js
@@ -63,7 +63,8 @@ async function verifyDiscordRequest(request, env) {
 	const timestamp = request.headers.get('x-signature-timestamp');
 
 	const body = await request.text();
-	const isValidRequest = signature && timestamp && verifyKey(body, signature, timestamp, env.DISCORD_APPLICATION_PUBLIC_KEY);
+	const isKeyVerified = await verifyKey(body, signature, timestamp, env.DISCORD_APPLICATION_PUBLIC_KEY);
+	const isValidRequest = signature && timestamp && isKeyVerified;
 
 	return { interaction: JSON.parse(body), isValid: isValidRequest };
 }


### PR DESCRIPTION
Fixes: 
- Issue with itty-router `router.handle()` being obsolete and non-working after upgrading to v5 (oops -- didn't follow migration guide)
- `verifyKey()` method not being `await`-ed on, which meant the key wasn't validated and Discord was unhappy